### PR TITLE
Add qc_fail reads to counts and stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ c/*.o
 examples/cgp_gnos_pull.ini
 /MYMETA.*
 /c/c_tests/tests_log
+/bin/diff_bams
+/bin/reheadSQ
+/c/c_tests/01_bam_stats_output_tests
+/c/c_tests/02_bam_access_tests
+/c/c_tests/03_bam_stats_calcs_tests

--- a/c/bam_access.h
+++ b/c/bam_access.h
@@ -41,6 +41,7 @@ typedef struct {
   uint64_t proper;
   uint64_t mapped_pairs;
   uint64_t inter_chr_pairs;
+  uint64_t qc_fail;
   //list of counts of possible insert sizes....
   khash_t(ins) *inserts; //from counts of insert size from 0-200000 bp. See how this works, might need amore dynamic means for some data.
   //FQP is not included as we're not covering quality plots yet.

--- a/c/bam_stats_output.c
+++ b/c/bam_stats_output.c
@@ -22,8 +22,8 @@
 #include "bam_stats_output.h"
 #include "bam_stats_calcs.h"
 
-static char *bas_header = "bam_filename\tsample\tplatform\tplatform_unit\tlibrary\treadgroup\tread_length_r1\tread_length_r2\t#_mapped_bases\t#_mapped_bases_r1\t#_mapped_bases_r2\t#_divergent_bases\t#_divergent_bases_r1\t#_divergent_bases_r2\t#_total_reads\t#_total_reads_r1\t#_total_reads_r2\t#_mapped_reads\t#_mapped_reads_r1\t#_mapped_reads_r2\t#_mapped_reads_properly_paired\t#_gc_bases_r1\t#_gc_bases_r2\tmean_insert_size\tinsert_size_sd\tmedian_insert_size\t#_duplicate_reads\t#_mapped_pairs\t#_inter_chr_pairs\n";
-static char *rg_line_pattern = "%s\t%s\t%s\t%s\t%s\t%s\t%"PRIu32"\t%"PRIu32"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%.3f\t%.3f\t%.3f\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\n";
+static char *bas_header = "bam_filename\tsample\tplatform\tplatform_unit\tlibrary\treadgroup\tread_length_r1\tread_length_r2\t#_mapped_bases\t#_mapped_bases_r1\t#_mapped_bases_r2\t#_divergent_bases\t#_divergent_bases_r1\t#_divergent_bases_r2\t#_total_reads\t#_total_reads_r1\t#_total_reads_r2\t#_mapped_reads\t#_mapped_reads_r1\t#_mapped_reads_r2\t#_mapped_reads_properly_paired\t#_gc_bases_r1\t#_gc_bases_r2\tmean_insert_size\tinsert_size_sd\tmedian_insert_size\t#_duplicate_reads\t#_mapped_pairs\t#_inter_chr_pairs\t#_qc_fail_r1\t#_qc_fail_r2\n";
+static char *rg_line_pattern = "%s\t%s\t%s\t%s\t%s\t%s\t%"PRIu32"\t%"PRIu32"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%.3f\t%.3f\t%.3f\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\t%"PRIu64"\n";
 
 
 int bam_stats_output_print_results(rg_info_t **grps,int grps_size,stats_rd_t*** grp_stats,char *input_file,char *output_file){
@@ -69,6 +69,9 @@ int bam_stats_output_print_results(rg_info_t **grps,int grps_size,stats_rd_t*** 
     uint64_t mapped_pairs = 0;
     uint64_t inter_chr_pairs = 0;
 
+    uint64_t qc_fail_r1 = 0;
+    uint64_t qc_fail_r2 = 0;
+
     double mean_insert_size = 0;
     double insert_size_sd = 0;
     double median_insert_size = 0;
@@ -95,6 +98,9 @@ int bam_stats_output_print_results(rg_info_t **grps,int grps_size,stats_rd_t*** 
 
     uint32_t read_length_r1 = grp_stats[i][0]->length;
     uint32_t read_length_r2 = grp_stats[i][1]->length;
+
+    qc_fail_r1 = grp_stats[i][0]->qc_fail;
+    qc_fail_r2 = grp_stats[i][1]->qc_fail;
 
     char *file = basename(input_file);
 
@@ -127,7 +133,9 @@ int bam_stats_output_print_results(rg_info_t **grps,int grps_size,stats_rd_t*** 
                       median_insert_size,
                       dup_reads,
                       mapped_pairs,
-                      inter_chr_pairs);
+                      inter_chr_pairs,
+                      qc_fail_r1,
+                      qc_fail_r2);
 
       check(chk>0,"Error writing bas line to output file.");
       fflush(out);

--- a/c/c_tests/01_bam_stats_output_tests.c
+++ b/c/c_tests/01_bam_stats_output_tests.c
@@ -21,14 +21,15 @@
 #include "minunit.h"
 #include "bam_stats_output.h"
 
-char err[100];
+char err[200];
 char *exp_file = "../t/data/Stats.c.bam.bas";
 char *input_file = "../t/data/Stats.bam";
 
 int compare_files(char *file1, char *file2){
   FILE *fp1;
   FILE *fp2;
-  char c1[500], c2[500];
+  int buffer_size = 600;
+  char c1[buffer_size], c2[buffer_size];
   int cmp;
   fp1 = fopen(file1, "r");
   fp2 = fopen(file2, "r");
@@ -36,9 +37,9 @@ int compare_files(char *file1, char *file2){
   if((fp1 == NULL) || (fp2 == NULL)){
     return -1;
   }else{
-    while((fgets(c1 , 500, fp1) != NULL) && (fgets(c2 , 500, fp2) != NULL)){
+    while((fgets(c1 , buffer_size, fp1) != NULL) && (fgets(c2 , buffer_size, fp2) != NULL)){
       if((cmp = strcmp(c1, c2)) != 0){
-        fprintf(stderr,"Expected: '%s'\nGot: '%s'",c1,c2);
+        fprintf(stderr,"Expected: '%s'\nGot     : '%s'",c1,c2);
         fclose(fp1);
         fclose(fp2);
         return -1;

--- a/c/c_tests/02_bam_access_tests.c
+++ b/c/c_tests/02_bam_access_tests.c
@@ -61,7 +61,7 @@ char *exp_platform_unit_1 = "5178_6";
 char *exp_rgid_2 = "29978";
 char *exp_platform_unit_2 = "5085_6";
 uint32_t exp_rd_length = 20;
-uint64_t exp_rg1_rd1_tot_count = 7;
+uint64_t exp_rg1_rd1_tot_count = 8;
 uint64_t exp_rg1_rd2_tot_count = 3;
 uint64_t exp_rg2_rd1_tot_count = 4;
 uint64_t exp_rg2_rd2_tot_count = 4;
@@ -69,7 +69,7 @@ uint64_t exp_rg1_rd1_dups = 4;
 uint64_t exp_rg1_rd2_dups = 0;
 uint64_t exp_rg2_rd1_dups = 0;
 uint64_t exp_rg2_rd2_dups = 0;
-uint64_t exp_rg1_rd1_gc = 63;
+uint64_t exp_rg1_rd1_gc = 72;
 uint64_t exp_rg1_rd2_gc = 27;
 uint64_t exp_rg2_rd1_gc = 71;
 uint64_t exp_rg2_rd2_gc = 74;
@@ -77,18 +77,22 @@ uint64_t exp_rg1_rd1_umap = 1;
 uint64_t exp_rg1_rd2_umap = 1;
 uint64_t exp_rg2_rd1_umap = 2;
 uint64_t exp_rg2_rd2_umap = 2;
-uint64_t exp_rg1_rd1_divergent = 30;
+uint64_t exp_rg1_rd1_divergent = 31;
 uint64_t exp_rg1_rd2_divergent = 18;
 uint64_t exp_rg2_rd1_divergent = 12;
 uint64_t exp_rg2_rd2_divergent = 12;
-uint64_t exp_rg1_rd1_mapped_bases = 115;
+uint64_t exp_rg1_rd1_mapped_bases = 135;
 uint64_t exp_rg1_rd2_mapped_bases = 37;
 uint64_t exp_rg2_rd1_mapped_bases = 95;
 uint64_t exp_rg2_rd2_mapped_bases = 95;
-uint64_t exp_rg1_rd1_proper = 6;
+uint64_t exp_rg1_rd1_proper = 7;
 uint64_t exp_rg1_rd2_proper = 0;
 uint64_t exp_rg2_rd1_proper = 2;
 uint64_t exp_rg2_rd2_proper = 0;
+uint64_t exp_rg1_rd1_qc_fail = 1;
+uint64_t exp_rg1_rd2_qc_fail = 0;
+uint64_t exp_rg2_rd1_qc_fail = 0;
+uint64_t exp_rg2_rd2_qc_fail = 0;
 
 char err[100];
 
@@ -323,7 +327,16 @@ char *test_bam_access_process_reads_rna(){ // rna flag in this method includes s
     sprintf(err,"RG 1, read_2 proper count incorrect. Expected %"PRIu64" but got %"PRIu64"\n",exp_rg1_rd2_proper,grp_stats[0][1]->proper);
     return err;
   }
-
+  //qc_fail 1
+  if(grp_stats[0][0]->qc_fail!=exp_rg1_rd1_qc_fail){
+    sprintf(err,"RG 1, read_1 qc_fail count incorrect. Expected %"PRIu64" but got %"PRIu64"\n",exp_rg1_rd1_qc_fail,grp_stats[0][0]->qc_fail);
+    return err;
+  }
+  //qc_fail 2
+  if(grp_stats[0][1]->qc_fail!=exp_rg1_rd2_qc_fail){
+    sprintf(err,"RG 1, read_2 qc_fail count incorrect. Expected %"PRIu64" but got %"PRIu64"\n",exp_rg1_rd2_qc_fail,grp_stats[0][1]->qc_fail);
+    return err;
+  }
 
 
 
@@ -394,6 +407,16 @@ char *test_bam_access_process_reads_rna(){ // rna flag in this method includes s
   //proper 2
   if(grp_stats[1][1]->proper!=exp_rg2_rd2_proper){
     sprintf(err,"RG 2, read_2 proper count incorrect. Expected %"PRIu64" but got %"PRIu64"\n",exp_rg2_rd2_proper,grp_stats[1][1]->proper);
+    return err;
+  }
+  //qc_fail 1
+  if(grp_stats[1][0]->qc_fail!=exp_rg2_rd1_qc_fail){
+    sprintf(err,"RG 2, read_1 qc_fail count incorrect. Expected %"PRIu64" but got %"PRIu64"\n",exp_rg2_rd1_qc_fail,grp_stats[1][0]->qc_fail);
+    return err;
+  }
+  //qc_fail 2
+  if(grp_stats[1][1]->qc_fail!=exp_rg2_rd2_qc_fail){
+    sprintf(err,"RG 2, read_2 qc_fail count incorrect. Expected %"PRIu64" but got %"PRIu64"\n",exp_rg2_rd2_qc_fail,grp_stats[1][1]->qc_fail);
     return err;
   }
 

--- a/t/data/Stats.c.bam.bas
+++ b/t/data/Stats.c.bam.bas
@@ -1,4 +1,4 @@
-bam_filename	sample	platform	platform_unit	library	readgroup	read_length_r1	read_length_r2	#_mapped_bases	#_mapped_bases_r1	#_mapped_bases_r2	#_divergent_bases	#_divergent_bases_r1	#_divergent_bases_r2	#_total_reads	#_total_reads_r1	#_total_reads_r2	#_mapped_reads	#_mapped_reads_r1	#_mapped_reads_r2	#_mapped_reads_properly_paired	#_gc_bases_r1	#_gc_bases_r2	mean_insert_size	insert_size_sd	median_insert_size	#_duplicate_reads	#_mapped_pairs	#_inter_chr_pairs
-Stats.bam	PD1234a	GAII	5178_6	PD1234a 140546_1054	29976	20	20	152	115	37	48	30	18	10	7	3	8	6	2	6	63	27	195.833	119.387	125.000	4	6	0
-Stats.bam	PD1234a	GAII	5085_6	PD1234a 140546_1054	29978	20	20	190	95	95	24	12	12	8	4	4	4	2	2	2	71	74	545.500	445.500	545.500	0	2	0
-Stats.bam	PD1234a	GAII	5086_6	PD1234a 140546_1054	29979	20	20	120	60	60	0	0	0	6	3	3	6	3	3	1	27	27	100.000	0.000	100.000	0	3	1
+bam_filename	sample	platform	platform_unit	library	readgroup	read_length_r1	read_length_r2	#_mapped_bases	#_mapped_bases_r1	#_mapped_bases_r2	#_divergent_bases	#_divergent_bases_r1	#_divergent_bases_r2	#_total_reads	#_total_reads_r1	#_total_reads_r2	#_mapped_reads	#_mapped_reads_r1	#_mapped_reads_r2	#_mapped_reads_properly_paired	#_gc_bases_r1	#_gc_bases_r2	mean_insert_size	insert_size_sd	median_insert_size	#_duplicate_reads	#_mapped_pairs	#_inter_chr_pairs	#_qc_fail_r1	#_qc_fail_r2
+Stats.bam	PD1234a	GAII	5178_6	PD1234a 140546_1054	29976	20	20	172	135	37	49	31	18	11	8	3	9	7	2	7	72	27	182.143	115.506	100.000	4	7	0	1	0
+Stats.bam	PD1234a	GAII	5085_6	PD1234a 140546_1054	29978	20	20	190	95	95	24	12	12	8	4	4	4	2	2	2	71	74	545.500	445.500	545.500	0	2	0	0	0
+Stats.bam	PD1234a	GAII	5086_6	PD1234a 140546_1054	29979	20	20	120	60	60	0	0	0	6	3	3	6	3	3	1	27	27	100.000	0.000	100.000	0	3	1	0	0


### PR DESCRIPTION
Merging into other feature `rg_metadata` following review.  In `c_tests/01_bam_stats_output_tests` I made the char array for comparisons larger (500 -> 600) and as I had to modify in 4 places defined a variable.  Hopefully correctly.

Updated tests as appropriate, RG1 had a QC fail read and so modified several values in the expected bas.