### PR TITLE
Expose fastcollate option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGES
 
+## NEXT
+
+* Expose option for "fastcollate" to allow proxy for <=5.0.5 processing methods.
+
 ## 5.1.0
 
 * Base image updated to Focal (Ubuntu 20.04).

--- a/bin/bwa_mem.pl
+++ b/bin/bwa_mem.pl
@@ -136,6 +136,7 @@ sub setup {
               'qf|mmqcfrac:f' => \$opts{'mmqcfrac'},
               'bm2|bwamem2' => \$opts{'bwamem2'},
               'd|dupmode:s' => \$opts{'dupmode'},
+              'fc|fastcollate' => \$opts{'fastcollate'},
               'ss|seqslice:i' => $opts{'seqslice'},
   ) or pod2usage(2);
 
@@ -178,6 +179,11 @@ sub setup {
   delete $opts{'mmqc'} unless(defined $opts{'mmqc'});
   delete $opts{'csi'} unless(defined $opts{'csi'});
   delete $opts{'bwamem2'} unless(defined $opts{'bwamem2'});
+  delete $opts{'fastcollate'} unless(defined $opts{'fastcollate'});
+
+  if(defined $opts{'bwamem2'} && defined $opts{'fastcollate'}) {
+    pod2usage(-msg  => "\nERROR: Options bwamem2 and fastcollate are incomptible.\n", -verbose => 1,  -output => \*STDERR);
+  }
 
   PCAP::Cli::opt_requires_opts('scramble', \%opts, ['cram']);
 
@@ -243,7 +249,7 @@ bwa_mem.pl [options] [file(s)...]
     -threads     -t    Number of threads to use. [1]
 
   Optional parameters:
-    -bwamem2     -bm2  Use bwa-mem2 instead of bwa.
+    -bwamem2     -bm2  Use bwa-mem2 instead of bwa (experimental).
     -fragment    -f    Split input into fragments of X million repairs [10]
                         - only applies to fastq[.gz] input
     -nomarkdup   -n    Don't mark duplicates [flag]
@@ -261,6 +267,9 @@ bwa_mem.pl [options] [file(s)...]
                         - Please see 'bwa_mem.pl -m'
     -mmqcfrac    -qf   Mismatch fraction for -mmqc [0.05]
     -dupmode     -d    see "samtools markdup -m" [t]
+    -fastcollate -fc   Paired with `-dupmode t` equivalent to PCAP-core<=5.0.5
+                        - Only relevant to BAM/CRAM input
+                        - not compatible with bwamem2
 
   Targeted processing:
     -process     -p    Only process this step then exit, optionally set -index
@@ -359,6 +368,18 @@ should not be split.
 =item B<-nomarkdup>
 
 Disables duplicate marking, switching bammarkduplicates2 for bammerge.
+
+=item B<-dupmode>
+
+Switch between template and sequence based marking.  See "samtools markdup" man page for more details
+
+=item B<-fastcollate>
+
+For BAM/CRAM, brings read pairs together but doesn't result in even distribution of read location during input to
+bwa-mem.  This can result in errors in read-pair placement and noise in data.  This was part of the processing in
+versions of PCAP-core <= 5.0.5.
+
+Not compaitible with bwa-mem2.
 
 =item B<-csi>
 

--- a/lib/PCAP/Bwa.pm
+++ b/lib/PCAP/Bwa.pm
@@ -208,13 +208,16 @@ sub split_in {
     }
     # if bam|cram input
     else {
+      my $fastcollate = q{};
+      $fastcollate = q{-f} if(exists $options->{fastcollate});
+
       my $helpers = $options->{threads_per_split};
       my $collate_folder = File::Spec->catdir($options->{'tmp'}, 'collate', $index);
       make_path($collate_folder) unless(-d $collate_folder);
       my $samtools = _which('samtools') || die "Unable to find 'samtools' in path";
       my $mmQcStrip = sprintf '%s --remove -l 0 -@ %d -i %s', _which('mmFlagModifier'), $helpers, $input->in;
       my $view = sprintf '%s view %s -bu -T %s -F 2816 -@ %d -', $samtools, $TAG_STRIP, $options->{'reference'}, $helpers; # leave
-      my $collate = sprintf '%s collate -Ou -@ %d - %s/collate', $samtools, $helpers, $collate_folder;
+      my $collate = sprintf '%s collate -Ou -@ %d %s - %s/collate', $samtools, $helpers, $fastcollate, $collate_folder;
       my $split = sprintf '%s split --output-fmt bam,level=1 -@ %d -u %s/unknown.bam -f %s/%%!_i.bam -', $samtools, $helpers, $split_folder, $split_folder;
       my $cmd = sprintf '%s | %s | %s | %s', $mmQcStrip, $view, $collate, $split;
       # treat as interleaved fastq


### PR DESCRIPTION
All CI successful and show to reinstate legacy behaviour when used in combination with `-dupmode t`.